### PR TITLE
message 'Swagger API response validation is {}' will be shown only if…

### DIFF
--- a/demo/demo/utils.py
+++ b/demo/demo/utils.py
@@ -55,9 +55,8 @@ def login_required_no_redirect(view_func):
                 if auth[0].lower() == "basic":
                     base_val = base64.b64decode(auth[1])
                     if sys.version_info[0] > 2:
-                        uname, passwd = base_val.split(b":")
-                    else:
-                        uname, passwd = base_val.split(":")
+                        base_val = base_val.decode()
+                    uname, passwd = base_val.split(":")
                     user = authenticate(username=uname, password=passwd)
                     if user and user.is_active:
                         login(request, user)

--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -25,9 +25,9 @@ try:
     VALIDATE_RESPONSES = settings.SWAGGER_API_VALIDATE_RESPONSES
 except AttributeError:
     VALIDATE_RESPONSES = False
-LOGGER.info("Swagger API response validation is {}".format(
-    "on" if VALIDATE_RESPONSES else "off"
-))
+    LOGGER.info("Swagger API response validation is {}".format(
+        "on" if VALIDATE_RESPONSES else "off"
+    ))
 
 # Set up the stub class. If it is not explicitly configured in the settings.py
 # file of the project, we default to a mocked class.

--- a/generated/views.py
+++ b/generated/views.py
@@ -25,9 +25,9 @@ try:
     VALIDATE_RESPONSES = settings.SWAGGER_API_VALIDATE_RESPONSES
 except AttributeError:
     VALIDATE_RESPONSES = False
-LOGGER.info("Swagger API response validation is {}".format(
-    "on" if VALIDATE_RESPONSES else "off"
-))
+    LOGGER.info("Swagger API response validation is {}".format(
+        "on" if VALIDATE_RESPONSES else "off"
+    ))
 
 # Set up the stub class. If it is not explicitly configured in the settings.py
 # file of the project, we default to a mocked class.

--- a/swagger_django_generator/templates/django/utils.py
+++ b/swagger_django_generator/templates/django/utils.py
@@ -56,9 +56,8 @@ def login_required_no_redirect(view_func):
                 if auth[0].lower() == "basic":
                     base_val = base64.b64decode(auth[1])
                     if sys.version_info[0] > 2:
-                        uname, passwd = base_val.split(b":")
-                    else:
-                        uname, passwd = base_val.split(":")
+                        base_val = base_val.decode()
+                    uname, passwd = base_val.split(":")
                     user = authenticate(username=uname, password=passwd)
                     if user and user.is_active:
                         login(request, user)

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -26,9 +26,9 @@ try:
     VALIDATE_RESPONSES = settings.SWAGGER_API_VALIDATE_RESPONSES
 except AttributeError:
     VALIDATE_RESPONSES = False
-LOGGER.info("Swagger API response validation is {}".format(
-    "on" if VALIDATE_RESPONSES else "off"
-))
+    LOGGER.info("Swagger API response validation is {}".format(
+        "on" if VALIDATE_RESPONSES else "off"
+    ))
 
 # Set up the stub class. If it is not explicitly configured in the settings.py
 # file of the project, we default to a mocked class.


### PR DESCRIPTION
… SWAGGER_API_VALIDATE_RESPONSES don't set in settings